### PR TITLE
Add Multi Channel Support For DVR

### DIFF
--- a/hikcamerabot/camera.py
+++ b/hikcamerabot/camera.py
@@ -24,6 +24,7 @@ class HikvisionCam:
         self.description = conf.description
         self._log.debug('Initializing %s', self.description)
         self._api = HikvisionAPI(conf=conf.api)
+        self.channel = conf.alert.video_gif.channel
 
         self._img = ImageProcessor()
         self.video_manager = VideoGifManager(conf)
@@ -51,7 +52,7 @@ class HikvisionCam:
         """Take and return full or resized snapshot from the camera."""
         self._log.debug('Taking snapshot from %s', self.description)
         try:
-            res = self._api.take_snapshot(stream=True)
+            res = self._api.take_snapshot(stream=True, channel=self.channel)
         except APIError:
             err_msg = f'Failed to take snapshot from {self.description}'
             self._log.error(err_msg)

--- a/hikcamerabot/clients/hikvision.py
+++ b/hikcamerabot/clients/hikvision.py
@@ -18,7 +18,8 @@ from hikcamerabot.exceptions import (APIError,
 
 
 class Endpoints(Enum):
-    PICTURE = 'ISAPI/Streaming/channels/102/picture?snapShotImageType=JPEG'
+    PICTURE_START = 'ISAPI/Streaming/channels/'
+    PICTURE_END = '/picture?snapShotImageType=JPEG'
     MOTION_DETECTION = 'ISAPI/System/Video/inputs/channels/1/motionDetection'
     LINE_CROSSING_DETECTION = 'ISAPI/Smart/LineDetection/1'
     INTRUSION_DETECTION = 'ISAPI/Smart/FieldDetection/1'
@@ -47,9 +48,9 @@ class HikvisionAPI:
         self._sess.auth = requests.auth.HTTPDigestAuth(conf.auth.user,
                                                        conf.auth.password)
 
-    def take_snapshot(self, stream=False):
+    def take_snapshot(self, stream=False, channel=0):
         """Take snapshot."""
-        return self._request(Endpoints.PICTURE.value, stream=stream)
+        return self._request(Endpoints.PICTURE_START.value + str(channel) + Endpoints.PICTURE_END.value, stream=stream)
 
     def get_alert_stream(self):
         """Get Alert Streams."""


### PR DESCRIPTION
Made a change to pass the channel configured in the video_gif configuration set to the URL that gets used to take a snapshot in order to work with a DVR where only one IP is available for the whole system.

The channel can now be used to configure multiple cameras on the DVR, for example:
Camera 1 - channel 101 / 102
Camera 2 - channel 201 / 202
Camera 3 - channel 301 / 302